### PR TITLE
Add action filter injection

### DIFF
--- a/BetterMixPlugin.cs
+++ b/BetterMixPlugin.cs
@@ -6,86 +6,109 @@ using MediaBrowser.Model.Serialization;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Entities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Jellyfin.Plugin.BetterMix.Configuration;
 using Jellyfin.Plugin.BetterMix.Backend;
-using Microsoft.Extensions.Logging;
+using Jellyfin.Plugin.BetterMix.Filters;
 
-namespace Jellyfin.Plugin.BetterMix
+namespace Jellyfin.Plugin.BetterMix;
+
+public class BetterMixPlugin : BasePlugin<PluginConfiguration>, IHasPluginConfiguration, IHasWebPages
 {
-    public class BetterMixPlugin : BasePlugin<PluginConfiguration>, IHasPluginConfiguration, IHasWebPages
-    {
-        public override Guid Id => Guid.Parse("573ed94b-6a8e-4f7e-977a-c0aef8d0bbff");
-        public override string Name => "BetterMix";
-        public override string Description => "BetterMix, a Jellyfin plugin for better Instant Mix.";
-        public static BetterMixPlugin Instance { get; private set; } = null!;
-        public readonly ILogger<BetterMixPlugin> Logger;
-        public readonly ILibraryManager LibraryManager;
-        public BetterMixBackendBase ActiveBackend;
+    public override Guid Id => Guid.Parse("573ed94b-6a8e-4f7e-977a-c0aef8d0bbff");
+    public override string Name => "BetterMix";
+    public override string Description => "BetterMix, a Jellyfin plugin for better Instant Mix.";
+    public static BetterMixPlugin Instance { get; private set; } = null!;
+    public readonly ILogger<BetterMixPlugin> Logger;
+    public readonly ILibraryManager LibraryManager;
+    public BetterMixBackendBase ActiveBackend;
 
-        public BetterMixPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILibraryManager libraryManager, ILogger<BetterMixPlugin> logger)
-            : base(applicationPaths, xmlSerializer)
+    public BetterMixPlugin(
+        IApplicationPaths applicationPaths,
+        IXmlSerializer xmlSerializer,
+        ILibraryManager libraryManager,
+        IServiceProvider serviceProvider,
+        IActionDescriptorCollectionProvider provider,
+        IHostApplicationLifetime hostApplicationLifetime,
+        ILogger<BetterMixPlugin> logger)
+        : base(applicationPaths, xmlSerializer)
+    {
+        Instance = this;
+        LibraryManager = libraryManager;
+        Logger = logger;
+
+        if (Configuration.SelectedBackend == "deejai")
         {
-            Instance = this;
-            LibraryManager = libraryManager;
-            Logger = logger;
-            
+            ActiveBackend = new DeejAiBackend();
+        }
+        else
+        {
+            ActiveBackend = new NativeBackend();
+        }
+
+
+        LibraryManager.ItemAdded += OnItemChanged;
+        LibraryManager.ItemRemoved += OnItemChanged;
+        LibraryManager.ItemUpdated += OnItemChanged;
+        ConfigurationChanged += OnConfigurationChanged;
+
+
+        hostApplicationLifetime.ApplicationStarted.Register(() => { TryAddFilter(provider, serviceProvider); });
+    }
+
+    public BaseItem? GetItemFromPath(string path)
+    {
+        BaseItem? item = LibraryManager.FindByPath(path, false);
+        if (item == null)
+        {
+            return null;
+        }
+        return item;
+    }
+
+    public IEnumerable<PluginPageInfo> GetPages()
+    {
+        yield return new PluginPageInfo
+        {
+            Name = "BetterMixConfig",
+            EmbeddedResourcePath = GetType().Namespace + ".Configuration.config.html",
+        };
+    }
+
+    internal void OnConfigurationChanged(object? sender, BasePluginConfiguration e)
+    {
+        if (e is PluginConfiguration)
+        {
+            Logger.LogInformation("BetterMix: Configuration changed.");
             if (Configuration.SelectedBackend == "deejai")
             {
-                ActiveBackend = new DeejAiBackend();
+                if (ActiveBackend is not DeejAiBackend)
+                {
+                    ActiveBackend = new DeejAiBackend();
+                }
             }
-            else
+            else if (ActiveBackend is not NativeBackend)
             {
                 ActiveBackend = new NativeBackend();
             }
-
-
-            LibraryManager.ItemAdded += OnItemChanged;
-            LibraryManager.ItemRemoved += OnItemChanged;
-            LibraryManager.ItemUpdated += OnItemChanged;
-            ConfigurationChanged += OnConfigurationChanged;
-        }
-        
-        internal void OnConfigurationChanged(object? sender, BasePluginConfiguration e)
-        {
-            if (e is PluginConfiguration)
-            {
-                Logger.LogInformation("BetterMix: Configuration changed.");
-                if (Configuration.SelectedBackend == "deejai")
-                {
-                    if (ActiveBackend is not DeejAiBackend)
-                    {
-                        ActiveBackend = new DeejAiBackend();
-                    }
-                }
-                else if (ActiveBackend is not NativeBackend)
-                {
-                    ActiveBackend = new NativeBackend();
-                }
-            }
-        }
-
-        public BaseItem? GetItemFromPath(string path)
-        {
-            BaseItem? item = LibraryManager.FindByPath(path, false);
-            if (item == null)
-            {
-                return null;
-            }
-            return item;
-        }
-
-        private void OnItemChanged(object? sender, ItemChangeEventArgs e)
-        {
-            ActiveBackend.AddDirectoryToScan(e.Item.ContainingFolderPath);
-        }
-
-        public IEnumerable<PluginPageInfo> GetPages()
-        {
-            yield return new PluginPageInfo
-            {
-                Name = "BetterMixConfig",
-                EmbeddedResourcePath = GetType().Namespace + ".Configuration.config.html",
-            };
         }
     }
+
+    private void OnItemChanged(object? sender, ItemChangeEventArgs e)
+    {
+        ActiveBackend.AddDirectoryToScan(e.Item.ContainingFolderPath);
+    }
+
+    private void TryAddFilter(IActionDescriptorCollectionProvider provider, IServiceProvider serviceProvider)
+    {
+        var count = provider.AddDynamicFilter<ItemInstantMixFilter>(serviceProvider, t =>
+        {
+            return t.MethodInfo.Name == "GetInstantMixFromItem"
+                && t.ControllerTypeInfo.FullName == "Jellyfin.Api.Controllers.InstantMixController";
+        });
+        Logger.LogInformation("BetterMix: {Count} action filter(s) added.", count);
+    }
 }
+

--- a/Controllers/BetterMixController.cs
+++ b/Controllers/BetterMixController.cs
@@ -1,50 +1,29 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.ComponentModel.DataAnnotations;
 using MediaBrowser.Controller.Dto;
-using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Dto;
-using Jellyfin.Data.Entities;
-using Jellyfin.Plugin.BetterMix.ModelBinders;
-using Jellyfin.Extensions;
-using Jellyfin.Plugin.BetterMix.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
-using MediaBrowser.Controller.Entities.Audio;
+using Jellyfin.Plugin.BetterMix.ModelBinders;
+using Jellyfin.Plugin.BetterMix.Services;
 
 namespace Jellyfin.Plugin.BetterMix.Controllers;
 
 [ApiController]
 [Route("BetterMix")]
-public class BetterMixController : ControllerBase
+public class BetterMixController(
+    BetterMixService betterMixService) : ControllerBase
 {
-    private readonly IUserManager m_userManager;
-    private readonly IDtoService m_dtoService;
-    private readonly ILibraryManager m_libraryManager;
-    private readonly IMusicManager m_musicManager;
-
-    public BetterMixController(
-        IUserManager userManager,
-        IDtoService dtoService,
-        IMusicManager musicManager,
-        ILibraryManager libraryManager)
-    {
-        m_userManager = userManager;
-        m_dtoService = dtoService;
-        m_musicManager = musicManager;
-        m_libraryManager = libraryManager;
-    }
+    private readonly BetterMixService m_betterMixService = betterMixService;
 
     [HttpGet("Items/{itemId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public ActionResult<QueryResult<BaseItemDto>> GetInstantMixFromItem(
+    public ActionResult<QueryResult<BaseItemDto>> GetBetterMixFromItem(
         [FromRoute, Required] Guid itemId,
         [FromQuery] Guid? userId,
         [FromQuery] int? limit,
@@ -54,52 +33,6 @@ public class BetterMixController : ControllerBase
         [FromQuery] int? imageTypeLimit,
         [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ImageType[] enableImageTypes)
     {
-        var user = userId.IsNullOrEmpty()
-            ? null
-            : m_userManager.GetUserById(userId.Value);
-        var item = m_libraryManager.GetItemById<BaseItem>(itemId, user);
-        if (item is null)
-        {
-            return NotFound();
-        }
-
-        var dtoOptions = new DtoOptions { Fields = fields }
-            .AddClientFields(User)
-            .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
-
-        int numsongs = limit ?? 200;
-
-        List<BaseItem>? items = null;
-        if (item is Audio)
-        {
-            items = BetterMixPlugin.Instance.ActiveBackend.GetPlaylistFromSong(item.Path, numsongs);
-        }
-
-        // fallback to Native Instant Mix
-        if (items is null)
-        {
-            BetterMixPlugin.Instance.Logger.LogInformation("BetterMix: Falling back to Native Instant Mix.");
-            items = m_musicManager.GetInstantMixFromItem(item, user, dtoOptions);
-        }
-
-        return GetResult(items, user, numsongs, dtoOptions);
+        return m_betterMixService.GenerateMix(itemId, userId, limit, fields, enableImages, enableUserData, imageTypeLimit, enableImageTypes, User);
     }
-
-    private QueryResult<BaseItemDto> GetResult(IReadOnlyList<BaseItem> items, User? user, int? limit, DtoOptions dtoOptions)
-    {
-        var totalCount = items.Count;
-
-        if (limit.HasValue && limit < items.Count)
-        {
-            items = items.Take(limit.Value).ToArray();
-        }
-
-        var result = new QueryResult<BaseItemDto>(
-            0,
-            totalCount,
-            m_dtoService.GetBaseItemDtos(items, dtoOptions, user));
-
-        return result;
-    }
-
 }

--- a/Filters/InjectActionFilter.cs
+++ b/Filters/InjectActionFilter.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+
+namespace Jellyfin.Plugin.BetterMix.Filters;
+
+public static class InjectActionFilter
+{
+    public static int AddDynamicFilter<T>(
+        this IActionDescriptorCollectionProvider provider,
+        IServiceProvider serviceProvider,
+        Func<ControllerActionDescriptor, bool> matcher)
+        where T : IFilterMetadata
+    {
+        var actionDescriptors = provider.ActionDescriptors.Items;
+
+        var targetActions = actionDescriptors.Where(ad =>
+        {
+            return ad is ControllerActionDescriptor cad && matcher(cad);
+        }).ToArray();
+
+        foreach (var action in targetActions)
+        {
+            var filter = ActivatorUtilities.CreateInstance<T>(serviceProvider);
+
+            var filterMetadata = action.FilterDescriptors;
+            filterMetadata.Add(new FilterDescriptor(filter, FilterScope.Global));
+        }
+
+        return targetActions.Length;
+    }
+}

--- a/Filters/ItemInstantMixFilter.cs
+++ b/Filters/ItemInstantMixFilter.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
+using MediaBrowser.Model.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Jellyfin.Plugin.BetterMix.Services;
+
+namespace Jellyfin.Plugin.BetterMix.Filters;
+
+public class ItemInstantMixFilter(BetterMixService service)
+        : IAsyncActionFilter
+{
+    private readonly BetterMixService m_instantMixService = service;
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var executedContext = await next();
+
+        if (executedContext.Result is ObjectResult objectResult &&
+            objectResult.Value is QueryResult<BaseItemDto> originalResult)
+        {
+            context.ActionArguments.TryGetValue("itemId", out var itemObj);
+            var itemId = itemObj as Guid?;
+            if (itemId == null)
+            {
+                return;
+            }
+
+            context.ActionArguments.TryGetValue("userId", out var userIdObj);
+            var userId = userIdObj as Guid?;
+
+            context.ActionArguments.TryGetValue("limit", out var limitObj);
+            var limit = limitObj as int?;
+
+            context.ActionArguments.TryGetValue("fields", out var fieldsObj);
+            var fields = fieldsObj as ItemFields[] ?? [];
+
+            context.ActionArguments.TryGetValue("enableImages", out var enableImagesObj);
+            var enableImages = enableImagesObj as bool?;
+
+            context.ActionArguments.TryGetValue("enableUserData", out var enableUserDataObj);
+            var enableUserData = enableUserDataObj as bool?;
+
+            context.ActionArguments.TryGetValue("imageTypeLimit", out var imageTypeLimitObj);
+            var imageTypeLimit = imageTypeLimitObj as int?;
+
+            context.ActionArguments.TryGetValue("enableImageTypes", out var enableImageTypesObj);
+            var enableImageTypes = enableImageTypesObj as ImageType[] ?? [];
+
+            var currentUser = context.HttpContext.User;
+
+            var newResult = m_instantMixService.GenerateMix(
+                itemId.Value, userId, limit, fields, enableImages,
+                enableUserData, imageTypeLimit, enableImageTypes, currentUser
+            );
+
+            executedContext.Result = new ObjectResult(newResult)
+            {
+                StatusCode = objectResult.StatusCode
+            };
+        }
+    }
+}

--- a/Registration/BetterMixRegistrator.cs
+++ b/Registration/BetterMixRegistrator.cs
@@ -1,0 +1,15 @@
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+using Jellyfin.Plugin.BetterMix.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.BetterMix.Registration;
+
+public class BetterMixRegistrator : IPluginServiceRegistrator
+{
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        serviceCollection.AddSingleton<BetterMixService>();
+    }
+}

--- a/Services/BetterMixService.cs
+++ b/Services/BetterMixService.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Security.Claims;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Controller.Library;
+using Microsoft.Extensions.Logging;
+using Jellyfin.Data.Entities;
+using Jellyfin.Extensions;
+using Jellyfin.Plugin.BetterMix.Extensions;
+
+namespace Jellyfin.Plugin.BetterMix.Services;
+
+public class BetterMixService(
+    IUserManager userManager,
+    ILibraryManager libraryManager,
+    IMusicManager musicManager,
+    IDtoService dtoService
+    )
+{
+    private readonly IUserManager m_userManager = userManager;
+    private readonly ILibraryManager m_libraryManager = libraryManager;
+    private readonly IMusicManager m_musicManager = musicManager;
+    private readonly IDtoService m_dtoService = dtoService;
+
+    public QueryResult<BaseItemDto> GenerateMix(
+        Guid itemId,
+        Guid? userId,
+        int? limit,
+        ItemFields[] fields,
+        bool? enableImages,
+        bool? enableUserData,
+        int? imageTypeLimit,
+        ImageType[] enableImageTypes,
+        ClaimsPrincipal currentUser)
+    {
+        var user = userId.IsNullOrEmpty()
+            ? null
+            : m_userManager.GetUserById(userId.Value);
+
+        // var item = m_libraryManager.GetItemById<BaseItem>(itemId, user);
+        var item = m_libraryManager.GetItemById<BaseItem>(itemId);
+        if (item is null)
+        {
+            return new QueryResult<BaseItemDto> { Items = [], TotalRecordCount = 0 };
+        }
+
+        var dtoOptions = new DtoOptions { Fields = fields }
+            .AddClientFields(currentUser)
+            .AddAdditionalDtoOptions(enableImages, enableUserData, imageTypeLimit, enableImageTypes);
+
+        int numsongs = limit ?? 200;
+
+        List<BaseItem>? items = null;
+        if (item is Audio)
+        {
+            items = BetterMixPlugin.Instance.ActiveBackend.GetPlaylistFromSong(item.Path, numsongs);
+        }
+
+        if (items is null)
+        {
+            BetterMixPlugin.Instance.Logger.LogInformation("BetterMix: Falling back to Native Instant Mix.");
+            items = m_musicManager.GetInstantMixFromItem(item, user, dtoOptions);
+        }
+
+        // Use the original controller helper if needed to wrap the result
+        var result = GetResult(items, user, numsongs, dtoOptions);
+        return result;
+    }
+
+    private QueryResult<BaseItemDto> GetResult(IReadOnlyList<BaseItem> items, User? user, int? limit, DtoOptions dtoOptions)
+    {
+        var totalCount = items.Count;
+
+        if (limit.HasValue && limit < items.Count)
+        {
+            items = items.Take(limit.Value).ToArray();
+        }
+
+        var result = new QueryResult<BaseItemDto>(
+            0,
+            totalCount,
+            m_dtoService.GetBaseItemDtos(items, dtoOptions, user));
+
+        return result;
+    }
+}


### PR DESCRIPTION
Use action filters instead of proxying. The user will now have no manual setup on their part, the plugin is plug and play. The controller will remain as of now.

- Moved the controller logic to a service to call it from both the action filter and the controller.
- Renamed the controller to BetterMixFromItem to avoid confusing it with the Jellyfin InstantMixFromItem controller when injecting filters.